### PR TITLE
Enforce numpy-style docstrings via ruff pydocstyle and numpydoc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,11 @@ repos:
       # Run the formatter
       - id: ruff-format
 
+  - repo: https://github.com/numpy/numpydoc
+    rev: v1.10.0
+    hooks:
+      - id: numpydoc-validation
+
   - repo: local
     hooks:
       - id: zuban

--- a/pwrAB/pwr_classes.py
+++ b/pwrAB/pwr_classes.py
@@ -1,3 +1,5 @@
+"""Power analysis classes for Welch's unequal-variance t-test in AB testing."""
+
 from __future__ import annotations
 
 from math import ceil, sqrt
@@ -52,7 +54,31 @@ def _t_isf(q: float, df: float) -> float:
 
 
 class ab_t2n_class:
-    """Power analysis class for AB testing with continuous outcomes using Welch's t-test."""
+    """
+    Power analysis class for AB testing with continuous outcomes using Welch's t-test.
+
+    Parameters
+    ----------
+    n : int, optional
+        Total number of observations (sum of observations for groups A and B).
+    percent_b : float, optional
+        Percentage of total observations allocated to group B (between 0 and 1,
+        e.g., input 0.5 for 50%).
+    mean_diff : float, optional
+        Difference in means of the two groups (mean_B - mean_A).
+    sd_a : float, default=1
+        Standard deviation of group A. Must be positive.
+    sd_b : float, default=1
+        Standard deviation of group B. Must be positive.
+    sig_level : float, optional
+        Significance level (Type I error probability). Must be between 0 and 1.
+    power : float, optional
+        Power of test (1 minus Type II error probability). Must be between 0 and 1.
+    alternative : {'two-sided', 'greater', 'less'}, default='two-sided'
+        Specifies the alternative hypothesis.
+    max_sample : int or float, default=1e07
+        Maximum sample size to search for when solving for n.
+    """
 
     def __init__(
         self,
@@ -227,7 +253,29 @@ class ab_t2n_class:
 
 
 class ab_t2n_prop_class:
-    """Power analysis class for AB testing with proportion outcomes using Welch's t-test."""
+    """
+    Power analysis class for AB testing with proportion outcomes using Welch's t-test.
+
+    Parameters
+    ----------
+    prop_a : float, optional
+        Proportion (success rate) of group A. Must be between 0 and 1.
+    prop_b : float, optional
+        Proportion (success rate) of group B. Must be between 0 and 1.
+    n : int, optional
+        Total number of observations (sum of observations for groups A and B).
+    percent_b : float, optional
+        Percentage of total observations allocated to group B (between 0 and 1,
+        e.g., input 0.5 for 50%).
+    sig_level : float, optional
+        Significance level (Type I error probability). Must be between 0 and 1.
+    power : float, optional
+        Power of test (1 minus Type II error probability). Must be between 0 and 1.
+    alternative : {'two-sided', 'greater', 'less'}, default='two-sided'
+        Specifies the alternative hypothesis.
+    max_sample : int or float, default=1e07
+        Maximum sample size to search for when solving for n.
+    """
 
     def __init__(
         self,

--- a/pwrAB/pwr_tests.py
+++ b/pwrAB/pwr_tests.py
@@ -1,3 +1,5 @@
+"""Functional API for power analysis of Welch's unequal-variance t-test in AB testing."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ select = [
     "A",      # flake8-builtins
     "PTH",    # flake8-use-pathlib
     "PL",     # pylint
+    "D",      # pydocstyle
 ]
 ignore = [
     "PLR0913", # too-many-arguments
@@ -174,6 +175,7 @@ ignore = [
 "test/**/*.py" = [
     "ANN",     # type annotations not required in tests
     "PLR2004", # magic values OK in tests
+    "D",       # docstrings not required in tests
 ]
 "pwrAB/__init__.py" = [
     "N999",    # Module name is valid for this package
@@ -184,7 +186,28 @@ ignore = [
     "PLR0915", # pwr_test methods need many statements for comprehensive parameter handling
 ]
 
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
 [tool.ruff.lint.isort]
 known-first-party = ["pwrAB"]
 force-single-line = false
 lines-after-imports = 2
+
+[tool.numpydoc_validation]
+# Cross-check that docstrings match signatures (PR01/PR02/RT01/...).
+# Presence and overall style are already enforced by Ruff's pydocstyle (D, numpy convention).
+checks = [
+    "all",   # report everything, except the opt-outs below
+    "GL08",  # missing docstring — handled by Ruff D
+    "ES01",  # extended summary not required
+    "EX01",  # examples section not required
+    "SA01",  # "See Also" section not required
+    "SS06",  # allow summaries to wrap across lines
+]
+# Skip private helpers, dunders, and the R-convention class constructors.
+exclude = [
+    '\._',          # private functions / methods
+    '\.__init__$',
+    '\.__repr__$',
+]


### PR DESCRIPTION
## Summary
Adds enforcement of numpy-style docstrings across two complementary layers:

- **Ruff pydocstyle (`D`, numpy convention)** — enforces docstring presence and section formatting on every lint run.
- **numpydoc-validation pre-commit hook** (`v1.10.0`) — adds the deeper cross-check that documented parameters match the actual signature (`PR01`/`PR02`), return sections exist, etc., on the public API. Configured via `[tool.numpydoc_validation]`.

## Changes
- `pyproject.toml`: add `D` to ruff lint `select`, `[tool.ruff.lint.pydocstyle] convention = "numpy"`, exempt tests from `D`, and add `[tool.numpydoc_validation]` config (opt out of `GL08`/`ES01`/`EX01`/`SA01`/`SS06`; exclude private helpers, `__init__`, `__repr__`).
- `.pre-commit-config.yaml`: add the `numpydoc-validation` hook.
- `pwrAB/pwr_classes.py` / `pwrAB/pwr_tests.py`: add module docstrings.
- `pwrAB/pwr_classes.py`: document `__init__` parameters on the public power-analysis classes (numpydoc pulls these into the class docstring).

## Verification
- `pre-commit run numpydoc-validation --all-files` → Passed
- `ruff check` + `ruff format --check` → Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)