### PR TITLE
CI: derive Python version matrix from pyproject.toml classifiers

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,21 +14,22 @@ permissions:
   contents: read
 
 jobs:
+  versions:
+    uses: ./.github/workflows/versions.yml
+
   lint-and-type-check:
     name: Lint and Type Check
+    needs: versions
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.14"]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ needs.versions.outputs.latest }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ needs.versions.outputs.latest }}
           cache: 'pip'
 
       - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,13 +13,17 @@ permissions:
   contents: read
 
 jobs:
+  versions:
+    uses: ./.github/workflows/versions.yml
+
   test:
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    needs: versions
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13", "3.14"]
+        python-version: ${{ fromJson(needs.versions.outputs.matrix) }}
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
@@ -42,7 +46,7 @@ jobs:
           pytest --cov=pwrAB --cov-report=term-missing --cov-report=xml
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == needs.versions.outputs.latest
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -1,0 +1,48 @@
+name: Resolve Python versions
+
+# Reusable workflow: parses the supported Python versions from pyproject.toml's
+# "Programming Language :: Python :: X.Y" classifiers and exposes them to callers.
+# Adding a new version is a one-line classifier change in pyproject.toml.
+
+on:
+  workflow_call:
+    outputs:
+      matrix:
+        description: "JSON array of supported Python versions, oldest to newest."
+        value: ${{ jobs.resolve.outputs.matrix }}
+      latest:
+        description: "The newest supported Python version."
+        value: ${{ jobs.resolve.outputs.latest }}
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: Resolve Python versions
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+      latest: ${{ steps.set.outputs.latest }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Read supported versions from pyproject.toml
+        id: set
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, tomllib
+          with open("pyproject.toml", "rb") as f:
+              data = tomllib.load(f)
+          prefix = "Programming Language :: Python :: "
+          vers = sorted(
+              (c[len(prefix):] for c in data["project"]["classifiers"]
+               if c.startswith(prefix) and "." in c[len(prefix):]),
+              key=lambda v: tuple(map(int, v.split("."))),
+          )
+          if not vers:
+              raise SystemExit("No 'Programming Language :: Python :: X.Y' classifiers found in pyproject.toml")
+          print("matrix=" + json.dumps(vers))
+          print("latest=" + vers[-1])
+          PY


### PR DESCRIPTION
## Summary

Replaces the hardcoded Python version lists in the **Tests** and **Code Quality** workflows with a single source of truth so adding a new Python version is a one-line change.

- New reusable workflow `.github/workflows/versions.yml` parses the `Programming Language :: Python :: X.Y` classifiers from `pyproject.toml` and exposes them as `matrix` (full list) and `latest` (newest) outputs.
- `python-package.yml` builds its test matrix from `matrix` and gates Codecov upload on `latest` (previously hardcoded `3.14`).
- `linter.yml` targets `latest` instead of a hardcoded matrix.
- The parse step `raise SystemExit`s if no classifiers are found, so a bad edit fails loudly rather than producing an empty matrix.

Behavior is unchanged today: the classifiers resolve to `["3.13", "3.14"]` with latest `3.14`, matching the previous hardcoded values.

## How to add a Python version going forward

Add one line to the classifiers in `pyproject.toml`:

```toml
    "Programming Language :: Python :: 3.15",
```

Both workflows pick it up automatically.

## Testing

- All three workflow files validated as parseable YAML locally.
- The embedded parse logic exercised against the real `pyproject.toml` → `matrix=["3.13","3.14"]`, `latest=3.14`.
- Full reusable-workflow wiring (`workflow_call` outputs + `fromJson`) is exercised by this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)